### PR TITLE
fix: disable vendor chunk for server build

### DIFF
--- a/lib/config-utils.js
+++ b/lib/config-utils.js
@@ -33,6 +33,12 @@ function makeServerConfig(webpackConfig) {
 		},
 		optimization: {
 			runtimeChunk: false,
+			splitChunks: {
+				cacheGroups: {
+					default: false,
+					vendors: false,
+				},
+			},
 		},
 		externals: nodeExternals({
 			allowlist: [


### PR DESCRIPTION
Webpack 4 automatically creates a vendor chunk but vue-server-render only allows one entry-point.

Fix:
https://github.com/webpack/webpack/issues/7343